### PR TITLE
Adding icons library into the project and styling improvements

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -205,3 +205,9 @@ task copyDownloadableDepsToLibs(type: Copy) {
 }
 
 apply from: file("../../node_modules/@react-native-community/cli-platform-android/native_modules.gradle"); applyNativeModulesAppBuildGradle(project)
+
+project.ext.vectoricons = [
+  iconFontNames: ['MaterialCommunityIcons.ttf']
+]
+apply from: "../../node_modules/react-native-vector-icons/fonts.gradle"
+

--- a/ios/OpenWeather/Info.plist
+++ b/ios/OpenWeather/Info.plist
@@ -50,6 +50,7 @@
 		<string>UIInterfaceOrientationPortrait</string>
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
+    <string>MaterialCommunityIcons.ttf</string>
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "react-native-gesture-handler": "^1.6.0",
     "react-native-location": "^2.5.0",
     "react-native-maps": "0.27.1",
+    "react-native-vector-icons": "^6.6.0",
     "react-navigation": "^4.2.2",
     "reactotron-react-native": "^4.0.3",
     "styled-components": "^5.0.1"

--- a/src/components/ForecastDetails/index.js
+++ b/src/components/ForecastDetails/index.js
@@ -1,6 +1,7 @@
 import React from 'react';
-import {Animated} from 'react-native';
+import {Animated, Text} from 'react-native';
 import {PanGestureHandler, State} from 'react-native-gesture-handler';
+import Icon from 'react-native-vector-icons/MaterialCommunityIcons';
 
 import LottieView from 'lottie-react-native';
 import LottieAnimationJson from '~/assets/lottie-animations/sunny.json';
@@ -9,10 +10,11 @@ import {
   Card,
   Header,
   Body,
+  DescriptionContainer,
   Wind,
   Temperature,
   WeatherInfo,
-  Umidity,
+  Humidity,
   Observations,
   BookmarkButton,
   ButtonText,
@@ -96,21 +98,28 @@ export default function ForecastDetails() {
               extrapolate: 'clamp',
             }),
           }}>
+          <Wind>M7º / L5º</Wind>
+
           <WeatherInfoContainer>
-            <Wind>M7º / L5º</Wind>
-            <Temperature>5º</Temperature>
-            <WeatherInfo>Light rain</WeatherInfo>
-            <Umidity>87 %</Umidity>
+            <DescriptionContainer>
+              <Temperature>5º</Temperature>
+              <WeatherInfo>Light rain</WeatherInfo>
+              <Humidity>
+                <Icon name="water-outline" size={25} />
+                <Text>87 %</Text>
+              </Humidity>
+            </DescriptionContainer>
+            <AnimationContainer>
+              <LottieView source={LottieAnimationJson} autoPlay loop />
+            </AnimationContainer>
           </WeatherInfoContainer>
-          <AnimationContainer>
-            <LottieView source={LottieAnimationJson} autoPlay loop />
-          </AnimationContainer>
-        </Body>
-        <Bottom>
+
           <Observations>
             Right now is 5ºC and feels like -1ºC outside. The wind is blowing
             around 8.7 km/h and the pressure is 1009 hPa.
           </Observations>
+        </Body>
+        <Bottom>
           <BookmarkButton>
             <ButtonText>Bookmark this location</ButtonText>
           </BookmarkButton>

--- a/src/components/ForecastDetails/styles.js
+++ b/src/components/ForecastDetails/styles.js
@@ -4,15 +4,9 @@ import styled from 'styled-components/native';
 export const Card = styled(Animated.View)`
   flex: 1;
   background: #fff;
-  border-top-left-radius: 10px;
-  border-top-right-radius: 10px;
+  border-radius: 10px;
   height: 100%;
-  margin: 30px 20px;
-  width: 90%;
-  left: 0;
-  right: 0;
-  top: 0;
-  position: absolute;
+  width: 100%;
 `;
 
 export const Header = styled(Animated.Text)`
@@ -26,44 +20,53 @@ export const Header = styled(Animated.Text)`
 `;
 
 export const Body = styled(Animated.View)`
-  flex-direction: row;
+  flex-direction: column;
+  padding: 25px;
 `;
 
 export const Wind = styled.Text`
-  padding: 20px 0 0 20px;
-  font-size: 18px;
+  font-size: 15px;
   font-weight: bold;
 `;
 
+export const WeatherInfoContainer = styled.View`
+  width: 100%;
+  flex-direction: row;
+  margin: 70px 0;
+`;
+
+export const DescriptionContainer = styled.View`
+  margin-right: 20px;
+`;
+
 export const Temperature = styled.Text`
-  padding: 0 0 0 20px;
-  margin-top: 70px;
   font-size: 70px;
 `;
 
 export const WeatherInfo = styled.Text`
-  padding: 0 0 0 20px;
-  font-size: 20px;
+  font-size: 18px;
   font-weight: bold;
 `;
 
-export const WeatherInfoContainer = styled.View``;
-
-export const Umidity = styled.Text`
-  padding: 0 0 0 20px;
-  margin-top: 70px;
-  font-size: 20px;
+export const Humidity = styled.View`
+  margin-top: 30px;
+  font-size: 15px;
   font-weight: bold;
+  align-items: center;
+  flex-direction: row;
+`;
+
+export const AnimationContainer = styled.View`
+  flex: 1;
 `;
 
 export const Observations = styled.Text`
-  padding: 30px 20px 0 20px;
+  font-size: 18px;
 `;
 
 export const BookmarkButton = styled.TouchableOpacity`
   padding: 15px;
   background-color: #7159c1;
-  margin: 30px 20px 0 20px;
   border-radius: 10px;
   align-items: center;
 `;
@@ -73,9 +76,7 @@ export const ButtonText = styled.Text`
   font-weight: bold;
 `;
 
-export const AnimationContainer = styled.View`
-  flex: 1;
-  margin: 10px;
+export const Bottom = styled.View`
+  margin-top: auto;
+  padding: 20px;
 `;
-
-export const Bottom = styled.View``;

--- a/src/pages/Main/index.js
+++ b/src/pages/Main/index.js
@@ -6,6 +6,8 @@ import MapView from 'react-native-maps';
 import {SafeAreaView} from 'react-navigation';
 import RNLocation from 'react-native-location';
 
+import {ForecastDetailsWrapper} from './styles';
+
 const styles = StyleSheet.create({
   container: {
     alignItems: 'center',
@@ -57,7 +59,9 @@ const Main = () => {
           style={{...StyleSheet.absoluteFillObject}}
         />
       )}
-      <ForecastDetails />
+      <ForecastDetailsWrapper>
+        <ForecastDetails />
+      </ForecastDetailsWrapper>
     </SafeAreaView>
   );
 };

--- a/src/pages/Main/styles.js
+++ b/src/pages/Main/styles.js
@@ -1,0 +1,8 @@
+import styled from 'styled-components/native';
+
+export const ForecastDetailsWrapper = styled.View`
+  flex: 1;
+  padding: 30px;
+  overflow: hidden;
+  background: transparent;
+`;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1995,6 +1995,15 @@ cliui@^4.0.0:
     strip-ansi "^4.0.0"
     wrap-ansi "^2.0.0"
 
+cliui@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/cliui/-/cliui-5.0.0.tgz#deefcfdb2e800784aa34f46fa08e06851c7bbbc5"
+  integrity sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==
+  dependencies:
+    string-width "^3.1.0"
+    strip-ansi "^5.2.0"
+    wrap-ansi "^5.1.0"
+
 cliui@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/cliui/-/cliui-6.0.0.tgz#511d702c0c4e41ca156d7d0e96021f23e13225b1"
@@ -4600,7 +4609,7 @@ lodash.unescape@4.0.1:
   resolved "https://registry.yarnpkg.com/lodash.unescape/-/lodash.unescape-4.0.1.tgz#bf2249886ce514cda112fae9218cdc065211fc9c"
   integrity sha1-vyJJiGzlFM2hEvrpIYzcBlIR/Jw=
 
-lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.5, lodash@^4.3.0:
+lodash@^4.0.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.5, lodash@^4.3.0:
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
@@ -5869,6 +5878,15 @@ react-native-safe-modules@^1.0.0:
   dependencies:
     dedent "^0.6.0"
 
+react-native-vector-icons@^6.6.0:
+  version "6.6.0"
+  resolved "https://registry.yarnpkg.com/react-native-vector-icons/-/react-native-vector-icons-6.6.0.tgz#66cf004918eb05d90778d64bd42077c1800d481b"
+  integrity sha512-MImKVx8JEvVVBnaShMr7/yTX4Y062JZMupht1T+IEgbqBj4aQeQ1z2SH4VHWKNtWtppk4kz9gYyUiMWqx6tNSw==
+  dependencies:
+    lodash "^4.0.0"
+    prop-types "^15.6.2"
+    yargs "^13.2.2"
+
 react-native@0.61.5:
   version "0.61.5"
   resolved "https://registry.yarnpkg.com/react-native/-/react-native-0.61.5.tgz#6e21acb56cbd75a3baeb1f70201a66f42600bba8"
@@ -6692,7 +6710,7 @@ string-width@^2.0.0, string-width@^2.1.0, string-width@^2.1.1:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^4.0.0"
 
-string-width@^3.0.0:
+string-width@^3.0.0, string-width@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-3.1.0.tgz#22767be21b62af1081574306f69ac51b62203961"
   integrity sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==
@@ -7322,6 +7340,15 @@ wrap-ansi@^2.0.0:
     string-width "^1.0.1"
     strip-ansi "^3.0.1"
 
+wrap-ansi@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-5.1.0.tgz#1fd1f67235d5b6d0fee781056001bfb694c03b09"
+  integrity sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==
+  dependencies:
+    ansi-styles "^3.2.0"
+    string-width "^3.0.0"
+    strip-ansi "^5.0.0"
+
 wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
@@ -7459,6 +7486,14 @@ yargs-parser@^11.1.1:
     camelcase "^5.0.0"
     decamelize "^1.2.0"
 
+yargs-parser@^13.1.2:
+  version "13.1.2"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-13.1.2.tgz#130f09702ebaeef2650d54ce6e3e5706f7a4fb38"
+  integrity sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==
+  dependencies:
+    camelcase "^5.0.0"
+    decamelize "^1.2.0"
+
 yargs-parser@^18.1.0:
   version "18.1.0"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-18.1.0.tgz#1b0ab1118ebd41f68bb30e729f4c83df36ae84c3"
@@ -7491,6 +7526,22 @@ yargs@^12.0.5:
     which-module "^2.0.0"
     y18n "^3.2.1 || ^4.0.0"
     yargs-parser "^11.1.1"
+
+yargs@^13.2.2:
+  version "13.3.2"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-13.3.2.tgz#ad7ffefec1aa59565ac915f82dccb38a9c31a2dd"
+  integrity sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==
+  dependencies:
+    cliui "^5.0.0"
+    find-up "^3.0.0"
+    get-caller-file "^2.0.1"
+    require-directory "^2.1.1"
+    require-main-filename "^2.0.0"
+    set-blocking "^2.0.0"
+    string-width "^3.0.0"
+    which-module "^2.0.0"
+    y18n "^4.0.0"
+    yargs-parser "^13.1.2"
 
 yargs@^15.0.0:
   version "15.3.0"


### PR DESCRIPTION
# Humidity Icon and general styling improvements

## Goal

Besides the icon, the intention is improving the styling by grouping some elements in order to be possible add other information without break the interface.

## Changeset

- developers can now use the [react-native-vector-icons / MaterialCommunityIcons](https://oblador.github.io/react-native-vector-icons/) to add icons related with weather through the interface.

<!-- This will be used to compile the release notes. Ex:
 - Users can now change their passwords.
 - The email bug was fixed.
 - Refactoring the product search that is now optimized.
 -->

## Discussion

Maybe we can use [this approach to naming Styled Components](https://medium.com/inturn-eng/naming-styled-components-d7097950a245) and differentiate them from react native components. The idea is to import styled components as `import * as S from './styles'` and then use `<S.Container />`, for example. It´ll also avoid some conflicts.

